### PR TITLE
Fixed name-spacing for SilverStripe v4 compatibility

### DIFF
--- a/code/HasOneButtonField.php
+++ b/code/HasOneButtonField.php
@@ -1,13 +1,13 @@
 <?php
 
+use SilverStripe\Control\Controller;
 use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldAddNewButton;
 use SilverStripe\Forms\GridField\GridFieldConfig;
 use SilverStripe\Forms\GridField\GridFieldDetailForm;
-use SilverStripe\Forms\GridField\GridFieldAddNewButton;
 use SilverStripe\Forms\GridField\GridField_HTMLProvider;
-use SilverStripe\Control\Controller;
-use SilverStripe\View\ArrayData;
 use SilverStripe\ORM\DataList;
+use SilverStripe\View\ArrayData;
 
 class HasOneButtonField extends GridField
 {

--- a/code/HasOneButtonField.php
+++ b/code/HasOneButtonField.php
@@ -56,7 +56,7 @@ class GridFieldHasOneEditButton extends GridFieldAddNewButton implements GridFie
         ));
 
         return array(
-            $this->targetFragment => $data->renderWith('GridFieldAddNewbutton')
+            $this->targetFragment => $data->renderWith('SilverStripe\Forms\GridField\GridFieldAddNewButton')
         );
     }
 }

--- a/code/HasOneButtonField.php
+++ b/code/HasOneButtonField.php
@@ -1,5 +1,14 @@
 <?php
 
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldConfig;
+use SilverStripe\Forms\GridField\GridFieldDetailForm;
+use SilverStripe\Forms\GridField\GridFieldAddNewButton;
+use SilverStripe\Forms\GridField\GridField_HTMLProvider;
+use SilverStripe\Control\Controller;
+use SilverStripe\View\ArrayData;
+use SilverStripe\ORM\DataList;
+
 class HasOneButtonField extends GridField
 {
 

--- a/code/HasOneButtonField.php
+++ b/code/HasOneButtonField.php
@@ -56,7 +56,7 @@ class GridFieldHasOneEditButton extends GridFieldAddNewButton implements GridFie
         ));
 
         return array(
-            $this->targetFragment => $data->renderWith('SilverStripe\Forms\GridField\GridFieldAddNewButton')
+            $this->targetFragment => $data->renderWith('SilverStripe\\Forms\\GridField\\GridFieldAddNewButton')
         );
     }
 }


### PR DESCRIPTION
Used [silverstripe-upgrader](https://github.com/silverstripe/silverstripe-upgrader) to fix name-spacing for SilverStripe v4. I then manually sorted the use declarations to visually group related namespaces.

Fixes: https://github.com/burnbright/silverstripe-hasonefield/issues/5.
